### PR TITLE
Fixed consul_deregister() for using PUT instead GET

### DIFF
--- a/res_discovery_consul.c
+++ b/res_discovery_consul.c
@@ -293,6 +293,7 @@ static CURLcode consul_deregister(CURL *curl)
 
 	headers = set_headers_json();
 
+	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(curl, CURLOPT_URL, ast_str_buffer(url));
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1);


### PR DESCRIPTION
It should use PUT for [Deregister Service](https://www.consul.io/api-docs/agent/service#deregister-service) instead GET.
Broken after aiyyo/servicestack-discovery-consul@e231034